### PR TITLE
add REST endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add bash curl jq;
 COPY --from=ghcr.io/strangelove-ventures/heighliner/gaia:v10.0.1 /bin/gaiad /usr/bin
 COPY --from=ghcr.io/duality-labs/duality:15cb02ba6b8c87723c7fd4bd4ce0c3bf660d6aff /bin/dualityd /usr/bin
 COPY --from=hermes-builder /usr/local/cargo/bin/hermes /usr/bin
+COPY --from=ghcr.io/tomwright/dasel:v2.3.4-alpine /usr/local/bin/dasel /usr/bin
 
 # add Go packages (with cache) for tx-sim
 WORKDIR /workspace
@@ -31,18 +32,26 @@ COPY scripts /workspace/scripts
 EXPOSE 26658
 # PROVIDER_GRPC_ADDR
 EXPOSE 9091
+# PROVIDER_LCD_LADDR
+EXPOSE 1318
 # PROVIDER_RPC_LADDR1
 EXPOSE 26668
 # PROVIDER_GRPC_ADDR1
 EXPOSE 9101
+# PROVIDER_LCD_LADDR1
+EXPOSE 1328
 # CONSUMER_RPC_LADDR
 EXPOSE 26648
 # CONSUMER_GRPC_ADDR
 EXPOSE 9081
+# CONSUMER_LCD_LADDR
+EXPOSE 1308
 # CONSUMER_RPC_LADDR1
 EXPOSE 26638
 # CONSUMER_GRPC_ADDR1
 EXPOSE 9071
+# CONSUMER_LCD_LADDR1
+EXPOSE 1298
 
 # by default use 0.0.0.0 for localhost to prevent internal traffic from blocking host traffic
 ENV NODE_IP=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -14,12 +14,16 @@ docker build -t duality:local-environments .
 docker run -it --init --rm \
   -p 26658:26658 \
   -p 9091:9091 \
+  -p 1318:1318 \
   -p 26668:26668 \
   -p 9101:9101 \
+  -p 1328:1328 \
   -p 26648:26648 \
   -p 9081:9081 \
+  -p 1308:1308 \
   -p 26638:26638 \
   -p 9071:9071 \
+  -p 1298:1298 \
   duality:local-environments
 
 # to just enter the environment (eg. to explore tx-sim) you can use

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ but it is best to not compile hermes in a non-native platform. During testing:
 ### Setup: OSX / Linux
 - Go v1.19
 - jq
+- dasel
 - dualityd
 
 To install Go and jq on OSX or Linux, you can use the following commands:
@@ -89,6 +90,7 @@ To run a full Duality deployment, you will need the following additional softwar
 - `gaiad` (v10.0.1 as used in duality-testnet-1 on Interchain Security)
 - `hermes`: IBC relayer (v1.5.1 as used in duality-testnet-1 on Interchain Security)
   - Rust (optional, v1.70 or later)
+- `dasel` (v2.3.4 for advanced editing of the TOML config files)
 
 To install dualityd, follow the instructions [here](https://github.com/duality-labs/duality/tree/v0.3.4).
   - or use Heighliner Docker image [ghcr.io/duality-labs/duality:15cb02ba6b8c87723c7fd4bd4ce0c3bf660d6aff](https://github.com/orgs/duality-labs/packages/container/duality/108783229?tag=15cb02ba6b8c87723c7fd4bd4ce0c3bf660d6aff) (specific commit for v0.3.4 release as specified by GitHub actions on the `main` branch commit or the release)
@@ -103,6 +105,9 @@ To install Hermes, follow the instructions [here](https://hermes.informal.system
     - this image can be problematic when running on Alpine Linux on an ARM CPU
 
 To install Rust, follow the instructions [here](https://www.rust-lang.org/tools/install).
+
+To install dasel, follow the instructions [here](https://daseldocs.tomwright.me/installation).
+  - or use the Docker image: [ghcr.io/tomwright/dasel:v2.3.4-alpine](https://github.com/TomWright/dasel/pkgs/container/dasel)
 
 To run a full Duality deployment, use the following script:
 

--- a/scripts/full-deployment/start_consumer.sh
+++ b/scripts/full-deployment/start_consumer.sh
@@ -15,12 +15,16 @@ CONSUMER_BINARY=${CONSUMER_BINARY:-dualityd}
 NODE_IP="${NODE_IP:-localhost}"
 PROVIDER_RPC_LADDR="$NODE_IP:26658"
 PROVIDER_GRPC_ADDR="$NODE_IP:9091"
+PROVIDER_REST_ADDR="$NODE_IP:1318"
 PROVIDER_RPC_LADDR1="$NODE_IP:26668"
 PROVIDER_GRPC_ADDR1="$NODE_IP:9101"
+PROVIDER_REST_ADDR1="$NODE_IP:1328"
 CONSUMER_RPC_LADDR="$NODE_IP:26648"
 CONSUMER_GRPC_ADDR="$NODE_IP:9081"
+CONSUMER_REST_ADDR="$NODE_IP:1308"
 CONSUMER_RPC_LADDR1="$NODE_IP:26638"
 CONSUMER_GRPC_ADDR1="$NODE_IP:9071"
+CONSUMER_REST_ADDR1="$NODE_IP:1298"
 CONSUMER_USER="consumer"
 PROVIDER_HOME="$HOME/.provider"
 PROVIDER_HOME1="$HOME/.provider1"
@@ -93,6 +97,12 @@ node=$($CONSUMER_BINARY tendermint show-node-id --home $CONSUMER_HOME)
 node1=$($CONSUMER_BINARY tendermint show-node-id --home $CONSUMER_HOME1)
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node1@localhost:26636\"/" "$CONSUMER_HOME"/config/config.toml
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node@localhost:26646\"/" "$CONSUMER_HOME1"/config/config.toml
+
+# Enable REST API with address
+dasel put -f "$CONSUMER_HOME"/config/app.toml -t bool ".api.enable" -v "true"
+dasel put -f "$CONSUMER_HOME"/config/app.toml -t string ".api.address" -v "tcp://$CONSUMER_REST_ADDR"
+dasel put -f "$CONSUMER_HOME1"/config/app.toml -t bool ".api.enable" -v "true"
+dasel put -f "$CONSUMER_HOME1"/config/app.toml -t string ".api.address" -v "tcp://$CONSUMER_REST_ADDR1"
 
 # Start the chain
 $CONSUMER_BINARY start \

--- a/scripts/full-deployment/start_consumer.sh
+++ b/scripts/full-deployment/start_consumer.sh
@@ -90,13 +90,15 @@ cp $PROVIDER_HOME1/config/priv_validator_key.json $CONSUMER_HOME1/config/priv_va
 cp $PROVIDER_HOME1/config/node_key.json $CONSUMER_HOME1/config/node_key.json
 
 ##########SET CONFIG.TOML#####################
-# Set default client port
-sed -i -r "/node =/ s/= .*/= \"tcp:\/\/${CONSUMER_RPC_LADDR1}\"/" $CONSUMER_HOME1/config/client.toml
-sed -i -r "/node =/ s/= .*/= \"tcp:\/\/${CONSUMER_RPC_LADDR}\"/" $CONSUMER_HOME/config/client.toml
 node=$($CONSUMER_BINARY tendermint show-node-id --home $CONSUMER_HOME)
 node1=$($CONSUMER_BINARY tendermint show-node-id --home $CONSUMER_HOME1)
+# Set persistent_peers with sed as an example of how to do so when dasel is not available
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node1@localhost:26636\"/" "$CONSUMER_HOME"/config/config.toml
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node@localhost:26646\"/" "$CONSUMER_HOME1"/config/config.toml
+
+# Set default RPC port
+dasel put -f "$CONSUMER_HOME"/config/config.toml -t string ".rpc.laddr" -v "tcp://$CONSUMER_RPC_LADDR"
+dasel put -f "$CONSUMER_HOME1"/config/config.toml -t string ".rpc.laddr" -v "tcp://$CONSUMER_RPC_LADDR1"
 
 # Enable REST API with address
 dasel put -f "$CONSUMER_HOME"/config/app.toml -t bool ".api.enable" -v "true"

--- a/scripts/full-deployment/start_consumer.sh
+++ b/scripts/full-deployment/start_consumer.sh
@@ -104,6 +104,12 @@ dasel put -f "$CONSUMER_HOME"/config/app.toml -t string ".api.address" -v "tcp:/
 dasel put -f "$CONSUMER_HOME1"/config/app.toml -t bool ".api.enable" -v "true"
 dasel put -f "$CONSUMER_HOME1"/config/app.toml -t string ".api.address" -v "tcp://$CONSUMER_REST_ADDR1"
 
+# Allow unsafe CORS requests for development
+dasel put -f "$CONSUMER_HOME"/config/app.toml -t bool ".api.enabled-unsafe-cors" -v "true"
+dasel put -f "$CONSUMER_HOME"/config/config.toml -t json ".rpc.cors_allowed_origins" -v '["*"]'
+dasel put -f "$CONSUMER_HOME1"/config/app.toml -t bool ".api.enabled-unsafe-cors" -v "true"
+dasel put -f "$CONSUMER_HOME1"/config/config.toml -t json ".rpc.cors_allowed_origins" -v '["*"]'
+
 # Start the chain
 $CONSUMER_BINARY start \
        --home $CONSUMER_HOME \

--- a/scripts/full-deployment/start_consumer.sh
+++ b/scripts/full-deployment/start_consumer.sh
@@ -96,9 +96,11 @@ node1=$($CONSUMER_BINARY tendermint show-node-id --home $CONSUMER_HOME1)
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node1@localhost:26636\"/" "$CONSUMER_HOME"/config/config.toml
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node@localhost:26646\"/" "$CONSUMER_HOME1"/config/config.toml
 
-# Set default RPC port
+# Set default RPC port for serving and for CLI client usage
 dasel put -f "$CONSUMER_HOME"/config/config.toml -t string ".rpc.laddr" -v "tcp://$CONSUMER_RPC_LADDR"
 dasel put -f "$CONSUMER_HOME1"/config/config.toml -t string ".rpc.laddr" -v "tcp://$CONSUMER_RPC_LADDR1"
+dasel put -f "$CONSUMER_HOME"/config/client.toml -t string ".node" -v "tcp://$CONSUMER_RPC_LADDR"
+dasel put -f "$CONSUMER_HOME1"/config/client.toml -t string ".node" -v "tcp://$CONSUMER_RPC_LADDR1"
 
 # Enable REST API with address
 dasel put -f "$CONSUMER_HOME"/config/app.toml -t bool ".api.enable" -v "true"

--- a/scripts/full-deployment/start_provider.sh
+++ b/scripts/full-deployment/start_provider.sh
@@ -90,6 +90,12 @@ dasel put -f "$PROVIDER_HOME"/config/app.toml -t string ".api.address" -v "tcp:/
 dasel put -f "$PROVIDER_HOME1"/config/app.toml -t bool ".api.enable" -v "true"
 dasel put -f "$PROVIDER_HOME1"/config/app.toml -t string ".api.address" -v "tcp://$PROVIDER_REST_ADDR1"
 
+# Allow unsafe CORS requests for development
+dasel put -f "$PROVIDER_HOME"/config/app.toml -t bool ".api.enabled-unsafe-cors" -v "true"
+dasel put -f "$PROVIDER_HOME"/config/config.toml -t json ".rpc.cors_allowed_origins" -v '["*"]'
+dasel put -f "$PROVIDER_HOME1"/config/app.toml -t bool ".api.enabled-unsafe-cors" -v "true"
+dasel put -f "$PROVIDER_HOME1"/config/config.toml -t json ".rpc.cors_allowed_origins" -v '["*"]'
+
 #################### Start the chain node1 ###################
 $PROVIDER_BINARY start \
 	--home $PROVIDER_HOME \

--- a/scripts/full-deployment/start_provider.sh
+++ b/scripts/full-deployment/start_provider.sh
@@ -15,8 +15,10 @@ VALIDATOR1=validator1
 NODE_IP="${NODE_IP:-localhost}"
 PROVIDER_RPC_LADDR="$NODE_IP:26658"
 PROVIDER_GRPC_ADDR="$NODE_IP:9091"
+PROVIDER_REST_ADDR="$NODE_IP:1318"
 PROVIDER_RPC_LADDR1="$NODE_IP:26668"
 PROVIDER_GRPC_ADDR1="$NODE_IP:9101"
+PROVIDER_REST_ADDR1="$NODE_IP:1328"
 PROVIDER_DELEGATOR=delegator
 
 # Clean start
@@ -81,6 +83,12 @@ node=$($PROVIDER_BINARY tendermint show-node-id --home $PROVIDER_HOME)
 node1=$($PROVIDER_BINARY tendermint show-node-id --home $PROVIDER_HOME1)
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node@localhost:26656\"/" "$PROVIDER_HOME1"/config/config.toml
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node1@localhost:26666\"/" "$PROVIDER_HOME"/config/config.toml
+
+# Enable REST API with address
+dasel put -f "$PROVIDER_HOME"/config/app.toml -t bool ".api.enable" -v "true"
+dasel put -f "$PROVIDER_HOME"/config/app.toml -t string ".api.address" -v "tcp://$PROVIDER_REST_ADDR"
+dasel put -f "$PROVIDER_HOME1"/config/app.toml -t bool ".api.enable" -v "true"
+dasel put -f "$PROVIDER_HOME1"/config/app.toml -t string ".api.address" -v "tcp://$PROVIDER_REST_ADDR1"
 
 #################### Start the chain node1 ###################
 $PROVIDER_BINARY start \

--- a/scripts/full-deployment/start_provider.sh
+++ b/scripts/full-deployment/start_provider.sh
@@ -76,13 +76,15 @@ sleep 1
 cp $PROVIDER_HOME1/config/genesis.json $PROVIDER_HOME/config/genesis.json
 
 ####################ADDING PEERS####################
-# Set default client port
-sed -i -r "/node =/ s/= .*/= \"tcp:\/\/${PROVIDER_RPC_LADDR}\"/" $PROVIDER_HOME/config/client.toml
-sed -i -r "/node =/ s/= .*/= \"tcp:\/\/${PROVIDER_RPC_LADDR1}\"/" $PROVIDER_HOME1/config/client.toml
 node=$($PROVIDER_BINARY tendermint show-node-id --home $PROVIDER_HOME)
 node1=$($PROVIDER_BINARY tendermint show-node-id --home $PROVIDER_HOME1)
+# Set persistent_peers with sed as an example of how to do so when dasel is not available
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node@localhost:26656\"/" "$PROVIDER_HOME1"/config/config.toml
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node1@localhost:26666\"/" "$PROVIDER_HOME"/config/config.toml
+
+# Set default RPC port
+dasel put -f "$PROVIDER_HOME"/config/config.toml -t string ".rpc.laddr" -v "tcp://$PROVIDER_RPC_LADDR"
+dasel put -f "$PROVIDER_HOME1"/config/config.toml -t string ".rpc.laddr" -v "tcp://$PROVIDER_RPC_LADDR1"
 
 # Enable REST API with address
 dasel put -f "$PROVIDER_HOME"/config/app.toml -t bool ".api.enable" -v "true"

--- a/scripts/full-deployment/start_provider.sh
+++ b/scripts/full-deployment/start_provider.sh
@@ -82,9 +82,11 @@ node1=$($PROVIDER_BINARY tendermint show-node-id --home $PROVIDER_HOME1)
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node@localhost:26656\"/" "$PROVIDER_HOME1"/config/config.toml
 sed -i -r "/persistent_peers =/ s/= .*/= \"$node1@localhost:26666\"/" "$PROVIDER_HOME"/config/config.toml
 
-# Set default RPC port
+# Set default RPC port for serving and for CLI client usage
 dasel put -f "$PROVIDER_HOME"/config/config.toml -t string ".rpc.laddr" -v "tcp://$PROVIDER_RPC_LADDR"
 dasel put -f "$PROVIDER_HOME1"/config/config.toml -t string ".rpc.laddr" -v "tcp://$PROVIDER_RPC_LADDR1"
+dasel put -f "$PROVIDER_HOME"/config/client.toml -t string ".node" -v "tcp://$PROVIDER_RPC_LADDR"
+dasel put -f "$PROVIDER_HOME1"/config/client.toml -t string ".node" -v "tcp://$PROVIDER_RPC_LADDR1"
 
 # Enable REST API with address
 dasel put -f "$PROVIDER_HOME"/config/app.toml -t bool ".api.enable" -v "true"


### PR DESCRIPTION
This changes the node configurations to allow the REST endpoints for each node to be exposed. And updates the README example with the command to bind these ports in Docker, and the new usage of `dasel`.